### PR TITLE
Update Singularity.def

### DIFF
--- a/third_party/poselib/Singularity.def
+++ b/third_party/poselib/Singularity.def
@@ -33,7 +33,7 @@ apt-get install -y software-properties-common lsb-release && \
 apt-get clean all
 wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
 apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main"
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6AF7F09730B3F0A4
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 6AF7F09730B3F0A4
 apt-get update
 apt-get -y install cmake
 cmake --version


### PR DESCRIPTION
Was throwing `gpg: keyserver receive failed: Server indicated a failure` error when building the singularity image. Fix from https://unix.stackexchange.com/questions/399027/gpg-keyserver-receive-failed-server-indicated-a-failure seems to work.
Not sure if this is reproducable or happens only with my setup.